### PR TITLE
Disable transport upgrading

### DIFF
--- a/src/webapp/index.js
+++ b/src/webapp/index.js
@@ -30,10 +30,19 @@ app.set('views', './views');
 app.set('view engine', 'mustache');
 app.engine('mustache', mustacheExpress());
 
+// The `upgrade-insecure-requests` directive of Content-Security-Policy must be
+// omitted until the production environment is served over HTTPS.
+const cspDirectives = Object.assign(
+  {}, helmet.contentSecurityPolicy.getDefaultDirectives()
+);
+delete cspDirectives['upgrade-insecure-requests'];
 app.use(helmet({
   // HSTS must be disabled until the production environment is served over
   // HTTPS.
   hsts: false,
+  contentSecurityPolicy: {
+    directives: cspDirectives,
+  }
 }));
 app.use('/static', express.static('static'));
 app.use(express.urlencoded({ extended: true }));


### PR DESCRIPTION
Although this is nominally in service of the production environment,
that environment may currently support HTTPS. The change is still
necessary to support the test environment.